### PR TITLE
chore: remove deprecated CONFIG_FROM_ENV env var

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"flag"
-	"fmt"
 	"log"
 	"log/slog"
 	"os"
@@ -38,10 +37,6 @@ func main() {
 		} else {
 			configPath = "config.yaml"
 		}
-	}
-
-	if os.Getenv("INTERNET_PERF_EXPORTER_CONFIG_FROM_ENV") == "true" {
-		fmt.Fprintln(os.Stderr, "Warning: INTERNET_PERF_EXPORTER_CONFIG_FROM_ENV is deprecated and has no effect. Env vars are always applied on top of yaml config.")
 	}
 
 	cfg, err := config.LoadConfig(configPath)


### PR DESCRIPTION
## Summary
The env var has been documented as deprecated/no-op for several releases. Env vars are always applied on top of yaml config unconditionally, so the deprecation warning is the only thing this code does.

Drop the warning block and the now-unused `fmt` import.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`